### PR TITLE
Corrige recuento de sacos de arena y agrega comandos para mostrar tiempo restante y estandariza ids de clientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quake II D-DAY: Normandy Release Game Source 5.044 Version Chile
+# Quake II D-DAY: Normandy Release Game Source 5.045 Version Chile
 
 Este repositorio contiene el código base del juego Quake II D-Day: Normandy, para los usuarios que deseen modificar el juego, junto con el código del juego original que se utilizó como referencia. Si bien este es un juego standalone, está basado en Quake II, por lo que para cargar el juego se debe utilizar el comando base `+set game dday` o `game dday` en la consola mientras el juego se está ejecutando.
 

--- a/src/g_cmds.c
+++ b/src/g_cmds.c
@@ -3259,39 +3259,10 @@ void Cmd_Medic_Call_f (edict_t *ent) {
 
 void Cmd_MOTD (edict_t *ent)
 {
-	//ala MOTD
-	FILE *motd_file;
-	char motd[1000];
-	char line[100];
-
-	// kernel: try to open from q2 directories
-	motd_file = DDay_OpenFullPathFile(sys_homedir->string, GAMEVERSION, "motd.txt", "r");
-
-	if (motd_file == NULL)
-		motd_file = DDay_OpenFullPathFile(sys_basedir->string, GAMEVERSION, "motd.txt", "r");
-
-	if (motd_file == NULL)
-		motd_file = DDay_OpenFullPathFile(".", GAMEVERSION, "motd.txt", "r");
-
-	if (motd_file != NULL)
-	{		
-		// we successfully opened the file "motd.txt"
-		if ( fgets(motd, 900, motd_file) )
-		{	
-			// we successfully read a line from "motd.txt" into motd
-			// ... read the remaining lines now
-			while ( fgets(line, 100, motd_file) )
-			{
-				// add each new line to motd, to create a BIG message string.
-				// we are using strcat: STRing conCATenation function here.
-				strcat(motd, line);
-			}
-
-			// print our message.
-			safe_centerprintf (ent, motd);
-		}
-		// be good now ! ... close the file
-		fclose(motd_file);
+	if (dday_motd[0])
+	{
+		// kernel: display the MOTD from its buffer
+		gi.centerprintf(ent, dday_motd);
 	}
 }
 

--- a/src/g_items.c
+++ b/src/g_items.c
@@ -1817,9 +1817,9 @@ void sandbag_die (edict_t *self, edict_t *inflictor, edict_t *attacker, int dama
 
 
 		if (self->obj_owner == 0)
-			allied_sandbags--;
+			level.allied_sandbags--;
 		else if (self->obj_owner == 1)
-			axis_sandbags--;
+			level.axis_sandbags--;
 
 
 	G_FreeEdict (self);
@@ -1855,9 +1855,9 @@ void sandbag_think (edict_t *ent)
 	else if (ent->obj_time < level.time - 5)
 	{
 		if (ent->obj_owner == 0)
-			allied_sandbags--;
+			level.allied_sandbags--;
 		else if (ent->obj_owner == 1)
-			axis_sandbags--;
+			level.axis_sandbags--;
 
 		ent->think = G_FreeEdict;
 	}
@@ -1872,16 +1872,14 @@ void sandbag_think (edict_t *ent)
 }
 
 void Weapon_Sandbag_Fire (edict_t *ent)
-
 {
 	edict_t	*sandbag;
 
-    
 	ent->client->ps.gunframe++;
 
 	if (ent->client->resp.team_on->index == 0)
 	{
-		if (allied_sandbags >= 12)
+		if (level.allied_sandbags >= 12)
 		{
 			safe_centerprintf(ent, "Your team is at the sandbag limit!\n");
 			return;
@@ -1889,7 +1887,7 @@ void Weapon_Sandbag_Fire (edict_t *ent)
 	}
 	else if (ent->client->resp.team_on->index == 1)
 	{
-		if (axis_sandbags >= 12)
+		if (level.axis_sandbags >= 12)
 		{
 			safe_centerprintf(ent, "Your team is at the sandbag limit!\n");
 			return;
@@ -1948,9 +1946,9 @@ void Weapon_Sandbag_Fire (edict_t *ent)
 		sandbag->obj_owner = ent->client->resp.team_on->index;
 
 	if (ent->client->resp.team_on->index == 0)
-		allied_sandbags++;
+		level.allied_sandbags++;
 	else if (ent->client->resp.team_on->index == 1)
-		axis_sandbags++;
+		level.axis_sandbags++;
 
 	sandbag->obj_time = level.time;
 

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -51,7 +51,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // the "gameversion" client command will print this plus compile date
 #define	GAMEVERSION	"dday"
-#define DEVVERSION	"5.044" // ddaychile
+#define DEVVERSION	"5.045" // ddaychile
 //#define	DEBUG		1
 
 // protocol bytes that can be directly added to messages

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -470,6 +470,9 @@ typedef struct
 
 	float		ctb_time;
 
+	int 		allied_sandbags;
+	int 		axis_sandbags;
+
 } level_locals_t;
 
 
@@ -2157,10 +2160,6 @@ typedef enum
 qboolean no_objectives_left;
 
 qboolean dropnodes;
-
-
-int	allied_sandbags;
-int axis_sandbags;
 
 
 char	*votemaps[5];

--- a/src/g_main.c
+++ b/src/g_main.c
@@ -1386,6 +1386,10 @@ if (campaign_winner>-1)
 			ent->health = ent->client->pers.max_health;
 	}
 
+	// reload MOTD
+	if (!DDay_LoadMOTD())
+		gi.dprintf("Failed to load the MOTD.\n");
+
 	//LevelExitUserDLLs();
 }
 

--- a/src/g_maps.h
+++ b/src/g_maps.h
@@ -30,9 +30,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "game.h"
 
+extern char dday_motd[1000];
+
 FILE *DDay_OpenFullPathFile(const char *path, const char *gamedir, const char *name, const char *mode);
 FILE *DDay_OpenFile (const char *filename_ptr);
 void DDay_CloseFile (FILE *fp);
+qboolean DDay_LoadTextFile(const char *filename, char *text, int len);
+qboolean DDay_LoadMOTD();
 
 #define MAX_MAPS           64 
 #define MAX_MAPNAME_LEN    16 

--- a/src/g_svcmds.c
+++ b/src/g_svcmds.c
@@ -558,7 +558,8 @@ void SVCmd_ListPlayers_f(void)
 
 		if (player->inuse && player->client)
 		{
-			gi.cprintf(NULL, PRINT_HIGH, "%2d   %s\n", i, player->client->pers.netname);
+			// kernel: reduce by one to get q2 id
+			gi.cprintf(NULL, PRINT_HIGH, "%2d   %s\n", i - 1, player->client->pers.netname);
 		}
 	}
 }
@@ -601,13 +602,14 @@ void SVCmd_KillPlayer_f()
 	}
 
 	int player_id = atoi(playerIdStr);
-	if (player_id < 1 || player_id > maxclients->value)
+	if (player_id < 0 || player_id >= maxclients->value)
 	{
-		gi.cprintf(NULL, PRINT_HIGH, "ID de jugador no válido. Debe estar entre 1 y %d.\n", (int)maxclients->value);
+		gi.cprintf(NULL, PRINT_HIGH, "ID de jugador no válido. Debe estar entre 0 y %d.\n", (int)maxclients->value - 1);
 		return;
 	}
 
-	edict_t* player = &g_edicts[player_id];
+	// kernel: when using client ids we need to sum 1 to get the right client
+	edict_t* player = &g_edicts[player_id + 1];
 	if (!player->inuse || !player->client)
 	{
 		gi.cprintf(NULL, PRINT_HIGH, "El jugador con ID %d no está en juego o no es valido.\n", player_id);

--- a/src/g_svcmds.c
+++ b/src/g_svcmds.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "g_local.h"
+#include "q_shared.h"
 #include <ctype.h> // Faltaba esta libreria para poder utilizar tolower - ZeRo
 
 
@@ -34,7 +35,7 @@ extern int countdownActive;
 extern int countdownValue;
 extern int countdownTimer;
 extern float countdownTimeLimit;
-
+extern float gameStartTime;
 
 
 void Svcmd_Teamswitch_f (void)
@@ -590,6 +591,31 @@ void SVCmd_StartCountdown_f()
 	int levelTimelimit = minutes * 60;
 }
 
+
+// kernel: broadcast the time left if a countdown is running
+void Svcmd_Timeleft_f()
+{
+	if (timelimit->value > 0)
+	{
+		int totalTime = timelimit->value * 60;
+		int timeElapsed = level.time - gameStartTime;
+		int timeLeft = totalTime - timeElapsed;
+
+		if (timeLeft < 0)
+			timeLeft = 0;
+
+		int minutesLeft = timeLeft / 60;
+		int secondsLeft = timeLeft % 60;
+
+		gi.bprintf(PRINT_HIGH, "Tiempo restante: %d minutos y %d segundos.\n", minutesLeft, secondsLeft);
+	}
+	else
+	{
+		gi.dprintf("No hay un limite de tiempo configurado para esta partida.\n");
+	}
+}
+
+
 // evil: command for kill a player by id
 void SVCmd_KillPlayer_f()
 {
@@ -663,13 +689,15 @@ void	ServerCommand (void)
 		Svcmd_Teamswitch_f();
 
 	else if (Q_stricmp(cmd, "startcount") == 0)
-		SVCmd_StartCountdown_f(gi.argv(1));
+		SVCmd_StartCountdown_f();
+	else if (Q_stricmp(cmd, "timeleft") == 0)
+		Svcmd_Timeleft_f();
 
 	else if (Q_stricmp(cmd, "listplayers") == 0)
 		SVCmd_ListPlayers_f();
 
 	else if (Q_stricmp(cmd, "killplayer") == 0)
-		SVCmd_KillPlayer_f(gi.argv(1));
+		SVCmd_KillPlayer_f();
 
 
 	else


### PR DESCRIPTION
- Se corrigen los errores SVCmd_ListPlayers_f() y SVCmd_KillPlayer_f() de g_svcmds.c para usar el ID Q2 (como el que se muestra en el comando "status") al listar y buscar clientes para eliminar.

- Se añade Svcmd_Timeleft_f() para implementar el nuevo comando de servidor "sv timeleft", que mostrará el tiempo restante si hay una cuenta regresiva en curso.

- Se añaden DDay_LoadTextFile() y DDay_LoadMOTD() a g_maps.c para cargar motd.txt en un búfer local y leer desde este en cada llamada a Cmd_MOTD(). Este cambio evita que se abra el archivo cada vez que un cliente se conecta o ejecuta un comando "motd".

- Se traslada allied_sandbags y axis_sandbags a la estructura level_locals_t, de modo que el recuento de sandbags se restablece al cambiar el mapa.