### PR TITLE
Corrección de bugs relacionados a los bots, votaciones al finalizar el mapa y errores en el tratamiento de torretas y puertas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quake II D-DAY: Normandy Release Game Source 5.045 Version Chile
+# Quake II D-DAY: Normandy Release Game Source 5.046 Version Chile
 
 Este repositorio contiene el código base del juego Quake II D-Day: Normandy, para los usuarios que deseen modificar el juego, junto con el código del juego original que se utilizó como referencia. Si bien este es un juego standalone, está basado en Quake II, por lo que para cargar el juego se debe utilizar el comando base `+set game dday` o `game dday` en la consola mientras el juego se está ejecutando.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,7 +41,7 @@ BASE_CFLAGS=-Dstricmp=strcasecmp
 CFLAGS_RELEASE=$(BASE_CFLAGS) -O3 -ffast-math -funroll-loops -fomit-frame-pointer -fexpensive-optimizations
 
 # Nick - Use 'make build_debug' to use this.
-CFLAGS_DEBUG=$(BASE_CFLAGS) -g -DDEBUG
+CFLAGS_DEBUG=$(CFLAGS_RELEASE) -g
 
 # uncomment for ARM64 cross-compilation
 #ARCH=aarch64

--- a/src/ai/bot_spawn.c
+++ b/src/ai/bot_spawn.c
@@ -748,7 +748,14 @@ void BOT_SpawnBot (int team, char *name, char *skin, char *userinfo)
 	bot->yaw_speed = 100;
 
 
-
+	// kernel: cleans up client data before spawn the bot (copied from PutClientInServer)
+	client_respawn_t resp = bot->client->resp;
+	client_persistant_t saved = bot->client->pers;
+	memset(bot->client, 0, sizeof(*bot->client));
+	bot->client->pers = saved;
+	if (bot->client->pers.health <= 0)
+		InitClientPersistant(bot->client);
+	bot->client->resp = resp;
 	InitClientResp(bot->client);
 
 	// To allow bots to respawn

--- a/src/g_ents.c
+++ b/src/g_ents.c
@@ -260,6 +260,15 @@ void SP_info_reinforcement_startx(edict_t *ent)
 
 } 
 
+// kernel: new place for team indexes
+int usa_index = 0;
+int rus_index = 0;
+int gbr_index = 0;
+int pol_index = 0;
+int usm_index = 0;
+int grm_index = 1;
+int ita_index = 1;
+int jpn_index = 1;
 
 gitem_t *InsertItem(gitem_t *it,spawn_t *spawnInfo);
 

--- a/src/g_func.c
+++ b/src/g_func.c
@@ -1138,7 +1138,11 @@ void door_blocked  (edict_t *self, edict_t *other)
 		if (self->moveinfo.state == STATE_DOWN)
 		{
 			for (ent = self->teammaster ; ent ; ent = ent->teamchain)
-				door_go_up (ent, ent->activator);
+			{
+				// kernel: do not open if no activator
+				if (ent->activator)
+					door_go_up(ent, ent->activator);
+			}
 		}
 		else
 		{

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -51,7 +51,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // the "gameversion" client command will print this plus compile date
 #define	GAMEVERSION	"dday"
-#define DEVVERSION	"5.045" // ddaychile
+#define DEVVERSION	"5.046" // ddaychile
 //#define	DEBUG		1
 
 // protocol bytes that can be directly added to messages

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -1160,6 +1160,7 @@ void G_RunEntity (edict_t *ent);
 void SaveClientData (void);
 void FetchClientEntData (edict_t *ent);
 void EndDMLevel (void);
+int HumanPlayerCount(void);
 void ResetCountTimer(void); //evil: for function in g_main.cs
 
 // 
@@ -1970,7 +1971,6 @@ typedef struct
 
 camp_spots_t camp_spots[128];
 int  total_camp_spots;
-int	num_clients;
 qboolean qbots;
 
 typedef struct

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -1918,15 +1918,16 @@ mapclasslimits_t mapclasslimits[MAX_TEAMS][10];
 
 
 
+// kernel: we need to initialize this indexes later
+extern int usa_index;
+extern int rus_index;
+extern int gbr_index;
+extern int pol_index;
+extern int usm_index;
+extern int grm_index;
+extern int ita_index;
+extern int jpn_index;
 
-int usa_index;
-int grm_index;
-int rus_index;
-int gbr_index;
-int pol_index;
-int ita_index;
-int jpn_index;
-int usm_index;
 
 #define SMG_SPREAD 20 // valor era 30 hans
 #define PISTOL_SPREAD 10 // valor era 40 hans

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -1059,7 +1059,12 @@ void SpawnEntities2 (char *mapname, char *entities, char *spawnpoint)
 	ent = NULL;
 	inhibit = 0;
 
-
+	// kernel: clear the counts for the next map ballot
+	mapvotes[0] = 0;
+	mapvotes[1] = 0;
+	mapvotes[2] = 0;
+	mapvotes[3] = 0;
+	mapvotes[4] = 0;
 
 	InitItems ();
 

--- a/src/g_turret.c
+++ b/src/g_turret.c
@@ -600,6 +600,11 @@ void turret_breach_die (edict_t *self, edict_t *inflictor, edict_t *attacker, in
 		else
 			turret_off(self->owner);
 	}
+
+	// kernel: sometimes the original entity has already been freed
+	if (!self->inuse)
+		return;
+
 	while ((t = G_Find (t, FOFS(classname), "turret_range")))
 	{
 		if (!t->inuse)
@@ -647,6 +652,11 @@ void turret_base_die (edict_t *self, edict_t *inflictor, edict_t *attacker, int 
 			G_FreeEdict(t);
 	}
 	t = NULL;*/
+
+	// kernel: sometimes the original entity has already been freed
+	if (!self->inuse)
+		return;
+
 	while ((t = G_Find (t, FOFS(classname), "turret_breach")))
 	{
 		if (!t->inuse)

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -3259,13 +3259,6 @@ void Count_Votes (void)
 	}
 
 	level.changemap = votemaps[highmap];
-
-	// kernel: clear the counts for the next map ballot
-	mapvotes[0] = 0;
-	mapvotes[1] = 0;
-	mapvotes[2] = 0;
-	mapvotes[3] = 0;
-	mapvotes[4] = 0;
 }
 
 qboolean Setup_Map_Vote (void)

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -2634,10 +2634,6 @@ void ClientBegin (edict_t *ent)
 	int		i;
 	
 	
-	num_clients++;
-
-
-
 	ent->client = game.clients + (ent - g_edicts - 1);
 	ent->client->resp.AlreadySpawned=false;
 
@@ -2968,8 +2964,6 @@ void ClientDisconnect (edict_t *ent)
 	if (!level.intermissiontime)
 		Write_Player_Stats(ent);
 
-	num_clients--;
-
 
 	change_stance(ent, STANCE_STAND);
 	
@@ -3272,7 +3266,6 @@ void Count_Votes (void)
 	mapvotes[2] = 0;
 	mapvotes[3] = 0;
 	mapvotes[4] = 0;
-	num_clients = 0;
 }
 
 qboolean Setup_Map_Vote (void)
@@ -3575,6 +3568,8 @@ void ClientThink (edict_t *ent, usercmd_t *ucmd)
 		}
 		if (level.map_vote_time > 0)
 		{
+			int num_clients = HumanPlayerCount();
+
 			if (level.time > level.map_vote_time + 15)
 			{
                 Count_Votes ();

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -3266,7 +3266,13 @@ void Count_Votes (void)
 
 	level.changemap = votemaps[highmap];
 
-
+	// kernel: clear the counts for the next map ballot
+	mapvotes[0] = 0;
+	mapvotes[1] = 0;
+	mapvotes[2] = 0;
+	mapvotes[3] = 0;
+	mapvotes[4] = 0;
+	num_clients = 0;
 }
 
 qboolean Setup_Map_Vote (void)


### PR DESCRIPTION
- Se corrige la función door_blocked() de g_func.c para evitar la invocación de door_go_up() cuando no hay activador.
- Se modifica BOT_SpawnBot() de bot_spawn.c para limpiar los datos del cliente antes de generar el bot (bloque adaptado de PutClientInServer).
- Se borran los recuentos para la siguiente votación del mapa al final de Count_Votes() de p_client.c.
- Se elimina la variable global num_clients y se reemplaza por una llamada a HumanPlayerCount() en p_client.c.
- Se corrige el error al eliminar votos de mapa: la matriz "mapvotes" debe borrarse en SpawnEntities2() de g_spawn.c después de cargar un nuevo mapa.
- Se traslada la definición de los índices de equipo a g_ents.c para inicializarlos.
- En turret_breach_die() y turret_base_die() de g_turret.c, agrega una verificación de entidad liberada antes de intentar trabajar en otras entidades de la torreta actual.