### PR TITLE
Corrige bug de cuerpos congelados al morir en el agua

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,14 @@
+Versión 5.066
+-------------
+
+- Fuerza el campo de visión estándar (STANDARD_FOV) en
+  PutClientInServer() de p_client.c, no es necesario copiarlo del
+  jugador, ya que cambiará durante el juego.
+
+- Corrige la condición en G_SetClientFrame() de p_view.c que comprueba
+  si hay animación cuando el jugador está en el agua, para que los
+  cuerpos muertos en el agua puedan completar la animación de muerte.
+
 Versión 5.065
 -------------
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,6 +12,11 @@ Versión 5.066
 - El método DropFlamed() de g_combat.c solo soltará un item y no vaciará
   el inventario de ese item.
 
+- Garantiza que afk_check_time se establezca en un valor distinto de
+  cero en InitClientPersistant() de p_client.c y se establezca en el
+  número de fotograma actual al cambiar o unirse a un equipo en
+  M_Team_Join() de p_observer.c.
+
 Versión 5.065
 -------------
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -9,6 +9,9 @@ Versión 5.066
   si hay animación cuando el jugador está en el agua, para que los
   cuerpos muertos en el agua puedan completar la animación de muerte.
 
+- El método DropFlamed() de g_combat.c solo soltará un item y no vaciará
+  el inventario de ese item.
+
 Versión 5.065
 -------------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quake II D-DAY: Normandy Release Game Source 5.065 Version Chile
+# Quake II D-DAY: Normandy Release Game Source 5.066 Version Chile
 
 Este repositorio contiene el código base del juego Quake II D-Day: Normandy, para los usuarios que deseen modificar el juego, junto con el código del juego original que se utilizó como referencia. Si bien este es un juego standalone, está basado en Quake II, por lo que para cargar el juego se debe utilizar el comando base `+set game dday` o `game dday` en la consola mientras el juego se está ejecutando.
 

--- a/src/g_combat.c
+++ b/src/g_combat.c
@@ -759,7 +759,7 @@ void Drop_Flamed (edict_t *ent)
 		if (ent->client->pers.inventory[index])
 		{
 			Drop_Item (ent, item);
-			ent->client->pers.inventory[index] = 0;
+			ent->client->pers.inventory[index]--; // kernel: drop only one item
 
 			ent->s.modelindex2 = 0; //faf:  remove the weapon model immediately or it looks like theres 2
 		}

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -51,7 +51,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // the "gameversion" client command will print this plus compile date
 #define	GAMEVERSION	"dday"
-#define DEVVERSION	"5.065" // ddaychile
+#define DEVVERSION	"5.066" // ddaychile
 //#define	DEBUG		1
 
 // protocol bytes that can be directly added to messages

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
 
+#include "ai/ai.h"
 #include "g_defines.h"
 #include "g_local.h"
 #include "g_maps.h"
@@ -1348,13 +1349,9 @@ void player_die (edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
 		if (!self->deadflag)
 		{
 			static int i;
-				i = (i+1)%3;
+			i = (i+1)%3;
 
-
-
-				
-				
-				// start a death animation
+			// start a death animation
 			self->client->anim_priority = ANIM_DEATH;
 			if (self->stanceflags==STANCE_DUCK)
 			{
@@ -2502,7 +2499,9 @@ void PutClientInServer (edict_t *ent)
 	client->ps.pmove.origin[1] = spawn_origin[1]*8;
 	client->ps.pmove.origin[2] = spawn_origin[2]*8;
 
-	if (deathmatch->value && ((int)dmflags->value & DF_FIXED_FOV))
+	// kernel: force the standard FOV
+	client->ps.fov = STANDARD_FOV;
+/*	if (deathmatch->value && ((int)dmflags->value & DF_FIXED_FOV))
 	{
 		client->ps.fov = STANDARD_FOV;
 	}
@@ -2513,7 +2512,7 @@ void PutClientInServer (edict_t *ent)
 			client->ps.fov = STANDARD_FOV;
 		else if (client->ps.fov > MAX_FOV)
 			client->ps.fov = MAX_FOV;
-	}
+	}*/
 
 	//if (client->pers.weapon)
 	//	client->ps.gunindex = gi.modelindex(client->pers.weapon->view_model);

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -1475,7 +1475,12 @@ void InitClientPersistant (gclient_t *client)
 	int afk_check_time;
 	vec3_t last_angles;
 
-	afk_check_time = client->pers.afk_check_time;
+	// kernel: copy AFK time only if was setted
+	if (client->pers.afk_check_time > 0)
+		afk_check_time = client->pers.afk_check_time;
+	else
+		afk_check_time = level.framenum;
+
 	VectorCopy(client->pers.last_angles, last_angles);
 
 	memset (&client->pers, 0, sizeof(client->pers));

--- a/src/p_observer.c
+++ b/src/p_observer.c
@@ -999,9 +999,9 @@ void M_Team_Join(edict_t *ent, pmenu_t *p, int choice)
 	{
 		ent->client->resp.team_on=team_list[choice];
 		safe_bprintf(PRINT_HIGH, "%s has joined team %s.\n", ent->client->pers.netname, ent->client->resp.team_on->teamname);
-		ent->client->pers.afk_check_time = level.framenum;
 	}
 
+	ent->client->pers.afk_check_time = level.framenum;
 	ent->client->resp.mos = NONE; // reset MOS
 
 	ent->client->resp.mos = INFANTRY;

--- a/src/p_view.c
+++ b/src/p_view.c
@@ -1912,12 +1912,12 @@ void G_SetClientFrame (edict_t *ent)
 	if (run != client->anim_run && client->anim_priority == ANIM_BASIC
 		&& !(run == false && client->sidestep_anim != 0))//faf: let them finish sidestepping
 		goto newanim;
-	if ((!ent->deadflag &&
-		 !ent->groundentity &&
-		 client->last_jump_time > level.time - 1 && //faf:  only do jump anims when jump is pressed
-		 client->anim_priority <= ANIM_WAVE) ||
-		ent->client->landed == false ||
-		(ent->waterlevel > 1 && ent->stanceflags != STANCE_CRAWL))
+	if (!ent->deadflag &&
+		((!ent->groundentity &&
+		   client->last_jump_time > level.time - 1 && //faf:  only do jump anims when jump is pressed
+		   client->anim_priority <= ANIM_WAVE) ||
+		 ent->client->landed == false ||
+		 (ent->waterlevel > 1 && ent->stanceflags != STANCE_CRAWL)))
 		goto newanim;
 	//faf: go to new sidestep animations immediately
 	if (extra_anims->value !=0 && 

--- a/src/p_view.c
+++ b/src/p_view.c
@@ -3173,18 +3173,26 @@ if (ent->client->turret)
 
 	VectorCopy (ent->s.origin, ent->client->last_pos1);
 
-	if (afk_time->value && level.framenum % 10 == 0 && ent->client->resp.team_on && !level.intermissiontime)
+	// kernel: AFK should not check bots
+	if (!ent->ai &&
+		afk_time->value &&
+		level.framenum % 10 == 0 &&
+		ent->client->resp.team_on &&
+		!level.intermissiontime)
 	{
-		//gi.dprintf ("checktime: %i time: %i diff: %i lastorg: %s movement: %s\n", ent->client->pers.afk_check_time,
-		//			level.framenum, level.framenum - ent->client->pers.afk_check_time, vtos(ent->client->pers.last_angles),
-		//			(ent->client->movement) ? "yes" : "no");
-
 		// kernel: add movement check
 		if (ent->client->movement || !VectorCompare(ent->s.angles, ent->client->pers.last_angles))
 			ent->client->pers.afk_check_time = level.framenum;
+
 		VectorCopy(ent->s.angles, ent->client->pers.last_angles);
 
-		if (!ent->ai && level.framenum - ent->client->pers.afk_check_time > (10 * afk_time->value))
+		//gi.dprintf("checktime: %i time: %i diff: %i last_angles: %s movement: %s\n", ent->client->pers.afk_check_time,
+		//		   level.framenum, level.framenum - ent->client->pers.afk_check_time, vtos(ent->client->pers.last_angles),
+		//		   (ent->client->movement) ? "yes" : "no");
+
+		if (!ent->ai &&
+			ent->client->pers.afk_check_time > 0 &&
+			level.framenum - ent->client->pers.afk_check_time > (10 * afk_time->value))
 		{
 			safe_bprintf(PRINT_HIGH, "%s is being removed from his team for being AFK.\n", ent->client->pers.netname);
 			DoObserverMode(ent);


### PR DESCRIPTION
- Corrige la condición en `G_SetClientFrame()` de p_view.c que comprueba si hay animación cuando el jugador está en el agua, para que los cuerpos muertos en el agua puedan completar la animación de muerte.

- Fuerza el campo de visión estándar (`STANDARD_FOV`) en `PutClientInServer()` de p_client.c, no es necesario copiarlo del jugador, ya que cambiará durante el juego.

- El método `DropFlamed()` de g_combat.c solo soltará un item y no vaciará el inventario de ese item.

- Garantiza que `afk_check_time` se establezca en un valor distinto de cero en `InitClientPersistant()` de p_client.c y se establezca en el número de fotograma actual al cambiar o unirse a un equipo en `M_Team_Join()` de p_observer.c.