### PR TITLE
Correcciones al modo CTB, remoción de bombas al iniciar cuenta regresiva, entre otros

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,6 +12,11 @@ Versión 5.067
   cuando el juego está en modo cooperativo. Se reemplaza por un bucle
   `for` que simplemente copia los objetos del inventario.
 
+- Añade la nueva función `TNT_Dud()` en g_weapon.c para desactivar TNT
+  activas. Esto permite usarla en la nueva función `RemoveTimeBombs()`
+  en g_items.c, que se aplicará al inicio de la cuenta atrás en el modo
+  torneo para eliminar granadas y TNT activas.
+
 Versión 5.066
 -------------
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -16,7 +16,9 @@ Versión 5.067
 - Añade la nueva función `TNT_Dud()` en g_weapon.c para desactivar TNT
   activas. Esto permite usarla en la nueva función `RemoveTimeBombs()`
   en g_items.c, que se aplicará al inicio de la cuenta atrás en el modo
-  torneo para eliminar granadas y TNT activas.
+  torneo para eliminar granadas y TNT activas. También se removerán los
+  llamados a ataques aéreos y cualquier avión que se esté desplazando
+  por el mapa.
 
 - Cambia probabilidad de quedar sangrando del pie en vez de morir a un
   50%.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -6,7 +6,8 @@ Versión 5.067
 
 - Agrega una comprobación de puntero nulo al verificar si el rifle de
   francotirador está completamente cargado en `Weapon_Generic()` de
-  p_generic_wep.c.
+  p_generic_wep.c y en `Weapon_Rifle_Fire()` de g_weapon.c cuando se
+  comprueba si hay munición cargada.
 
 - Comenta la línea que copia las estructuras de `coop_respawn` a `pers`
   cuando el juego está en modo cooperativo. Se reemplaza por un bucle

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,17 @@
+Versión 5.067
+-------------
+
+- Agrega una llamada a la función `KillBox()` para hacer espacio después
+  de mover el maletín en `briefcase_spawn_think()` de g_objectives.c.
+
+- Agrega una comprobación de puntero nulo al verificar si el rifle de
+  francotirador está completamente cargado en `Weapon_Generic()` de
+  p_generic_wep.c.
+
+- Comenta la línea que copia las estructuras de `coop_respawn` a `pers`
+  cuando el juego está en modo cooperativo. Se reemplaza por un bucle
+  `for` que simplemente copia los objetos del inventario.
+
 Versión 5.066
 -------------
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -17,6 +17,9 @@ Versión 5.067
   en g_items.c, que se aplicará al inicio de la cuenta atrás en el modo
   torneo para eliminar granadas y TNT activas.
 
+- Cambia probabilidad de quedar sangrando del pie en vez de morir a un
+  50%.
+
 Versión 5.066
 -------------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quake II D-DAY: Normandy Release Game Source 5.066 Version Chile
+# Quake II D-DAY: Normandy Release Game Source 5.067 Version Chile
 
 Este repositorio contiene el código base del juego Quake II D-Day: Normandy, para los usuarios que deseen modificar el juego, junto con el código del juego original que se utilizó como referencia. Si bien este es un juego standalone, está basado en Quake II, por lo que para cargar el juego se debe utilizar el comando base `+set game dday` o `game dday` en la consola mientras el juego se está ejecutando.
 

--- a/src/g_arty.c
+++ b/src/g_arty.c
@@ -824,6 +824,7 @@ void Spawn_Plane(edict_t *ent)
 	plane->die = plane_die;
 */
 	plane->classname = "plane";
+	plane->classnameb = PLANE;
 
 	plane->think = Plane_Think;
 	plane->nextthink = level.time +.1;
@@ -1086,6 +1087,7 @@ void Drop_Bomb_i(edict_t *ent)
 	bomb->dmg_radius = 300;
 	bomb->s.sound = gi.soundindex ("weapons/rockfly.wav");
 	bomb->classname = "bomb";
+	bomb->classnameb = BOMB;
 	bomb->gravity = 1; // faf
 	gi.linkentity (bomb);
 }

--- a/src/g_combat.c
+++ b/src/g_combat.c
@@ -676,7 +676,7 @@ int Damage_Loc(edict_t *targ, vec3_t point, edict_t *attacker)
 #define	BLEND_TIME 2		// How long the player is affected by damage.. (seconds)
 //bcass start - 3% chance of being shot/function to do it
 #define DROP_SHOT 97
-#define BLEEDING_FEET_WOUND 30 // kernel: 70% chance of a bleeding feet wound
+#define BLEEDING_FEET_WOUND 50 // kernel: 50% chance of a bleeding feet wound
 
 //void Drop_Shot (edict_t *ent, gitem_t *item);
 void Use_Weapon (edict_t *ent, gitem_t *inv);

--- a/src/g_items.c
+++ b/src/g_items.c
@@ -2240,3 +2240,24 @@ void RemoveSandbags(void)
 		}
 	}
 }
+
+void TNT_Dud(edict_t *ent);
+void Shrapnel_Dud(edict_t *ent);
+
+void RemoveTimeBombs(void)
+{
+	int i;
+	edict_t *ent;
+
+	for (i = 0; i < MAX_EDICTS; ++i)
+	{
+		ent = &g_edicts[i];
+		if (!ent->inuse)
+			continue;
+
+		if (ent->classnameb == TNT)
+			TNT_Dud(ent);
+		else if (ent->classnameb == HGRENADE)
+			Shrapnel_Dud(ent);
+	}
+}

--- a/src/g_items.c
+++ b/src/g_items.c
@@ -2259,5 +2259,20 @@ void RemoveTimeBombs(void)
 			TNT_Dud(ent);
 		else if (ent->classnameb == HGRENADE)
 			Shrapnel_Dud(ent);
+		else if (ent->classnameb == AIRSTRIKE ||
+				 ent->classnameb == AIRSTRIKE_CALLED ||
+				 ent->classnameb == PLANE ||
+				 ent->classnameb == BOMB)
+		{
+			gi.bprintf(PRINT_HIGH, "Removing %s\n", ent->classname);
+			G_FreeEdict(ent);
+		}
+		else if (ent->client && ent->client->airstrike)
+		{
+			gi.bprintf(PRINT_HIGH, "Removing ongoing airstrike from %s\n", ent->client->pers.netname);
+			if (ent->client->airstrike->inuse)
+				G_FreeEdict(ent->client->airstrike);
+			ent->client->airstrike = NULL;
+		}
 	}
 }

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -51,7 +51,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // the "gameversion" client command will print this plus compile date
 #define	GAMEVERSION	"dday"
-#define DEVVERSION	"5.066" // ddaychile
+#define DEVVERSION	"5.067" // ddaychile
 //#define	DEBUG		1
 
 // protocol bytes that can be directly added to messages

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -2194,7 +2194,11 @@ typedef enum
 	ROCKET,
 	FUNC_TRAIN,
 	BOTWARN,
-	OBJECTIVE_VIP
+	OBJECTIVE_VIP,
+	AIRSTRIKE,
+	AIRSTRIKE_CALLED,
+	PLANE,
+	BOMB
 } classnameb_t;
 
 typedef enum

--- a/src/g_objectives.c
+++ b/src/g_objectives.c
@@ -793,6 +793,10 @@ void briefcase_spawn_think(edict_t *ent)
 			idx = rand() % briefcase_count;
 			VectorCopy(level.briefcase_origin[idx], ent->s.origin);
 			VectorCopy(level.briefcase_angles[idx], ent->s.angles);
+
+			// kernel: must remove entities near the spawn point
+			KillBox(ent);
+
 			ent->think = briefcase_spawn_unhide; // kernel: reveal after movement
 			ent->nextthink = level.time + 1;
 		}

--- a/src/g_svcmds.c
+++ b/src/g_svcmds.c
@@ -576,6 +576,7 @@ void SVCmd_ListPlayers_f(void)
 
 void StartCount(int seconds);
 void RemoveSandbags(void);
+void RemoveTimeBombs(void);
 
 // evil: command for set and start countdown 
 void SVCmd_StartCountdown_f()
@@ -611,8 +612,9 @@ void StartCount(int seconds)
 
 	if (tournament->value && freeze_remaining <= 0)
 	{
-		// kernel: remove sandbags
+		// kernel: remove sandbags, live grenades and TNT
 		RemoveSandbags();
+		RemoveTimeBombs();
 
 		// kernel: check if there are players outside their spawn protect areas
 		for (i = 1; i <= maxclients->value; i++)

--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -3923,6 +3923,13 @@ void TNT_Explode (edict_t *ent)
     G_FreeEdict (ent);
 }
 
+void TNT_Dud(edict_t *ent)
+{
+	if (ent->owner && ent->owner->client)
+		safe_centerprintf(ent->owner, "Your TNT did not go off!\n");
+
+	G_FreeEdict(ent);
+}
 
 void TNT_Touch (edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 {

--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -2527,7 +2527,7 @@ void Weapon_Rifle_Fire (edict_t *ent)
 		ent->client->ps.gunframe = ((ent->client->aim)? guninfo->LastAFire : guninfo->LastFire) + 1;
 
 
-	if ( *ent->client->p_rnd == 0 )
+	if (ent->client->p_rnd && *ent->client->p_rnd == 0)
 	{
 		ent->client->ps.gunframe = ((ent->client->aim)? guninfo->LastAFire : guninfo->LastFire) + 1;
 

--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -2115,6 +2115,7 @@ void fire_airstrike (edict_t *self, vec3_t start, vec3_t dir, int damage, int sp
 	airstrike->dmg_radius = damage_radius;
 	airstrike->s.sound = gi.soundindex ("weapons/rockfly.wav");
 	airstrike->classname = "airstrike";
+	airstrike->classnameb = AIRSTRIKE;
 //	airstrike->gravity = .5; // faf
 
 

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -2429,7 +2429,11 @@ void PutClientInServer (edict_t *ent)
 			if (itemlist[n].flags & IT_KEY)
 				resp.coop_respawn.inventory[n] = client->pers.inventory[n];
 		}
-		client->pers = resp.coop_respawn;
+		// kernel: replace this by just copying what changed
+		//client->pers = resp.coop_respawn;
+		for (n = 0; n < MAX_ITEMS; n++)
+			client->pers.inventory[n] = resp.coop_respawn.inventory[n];
+
 		globals.ClientUserinfoChanged (ent, userinfo);
 //		if (resp.score > client->pers.score)
 //			client->pers.score = resp.score;

--- a/src/p_generic_wep.c
+++ b/src/p_generic_wep.c
@@ -411,7 +411,7 @@ void Weapon_Generic (edict_t *ent,
 		// Nerfeo recarga automatica doble pipa
 		if (ent->client->pers.weapon->position == LOC_SNIPER)
 		{
-			if (*ent->client->p_rnd == ammo_item->quantity) //if fully loaded, assume it's bolted
+			if (ent->client->p_rnd && *ent->client->p_rnd == ammo_item->quantity) //if fully loaded, assume it's bolted
 				ent->client->sniper_loaded[ent->client->resp.team_on->index] = true;
 		}
 

--- a/src/p_weapon.c
+++ b/src/p_weapon.c
@@ -2063,6 +2063,7 @@ void Binocular_Fire(edict_t *ent)
 
 	VectorCopy(tr.endpos, airstrike->pos2);
 	airstrike->classname ="airstrike_called";
+	airstrike->classnameb = AIRSTRIKE_CALLED;
 	airstrike->owner = ent;
 
 	// kernel: add arty_confirm delay to nextthink


### PR DESCRIPTION
- Agrega una llamada a la función `KillBox()` para hacer espacio después de mover el maletín en `briefcase_spawn_think()` de g_objectives.c.

- Agrega una comprobación de puntero nulo al verificar si el rifle de francotirador está completamente cargado en `Weapon_Generic()` de p_generic_wep.c y en `Weapon_Rifle_Fire()` de g_weapon.c cuando se comprueba si hay munición cargada.

- Comenta la línea que copia las estructuras de `coop_respawn` a `pers` cuando el juego está en modo cooperativo. Se reemplaza por un bucle `for` que simplemente copia los objetos del inventario.

- Añade la nueva función `TNT_Dud()` en g_weapon.c para desactivar TNT activas. Esto permite usarla en la nueva función `RemoveTimeBombs()` en g_items.c, que se aplicará al inicio de la cuenta atrás en el modo torneo para eliminar granadas y TNT activas. También se removerán los llamados a ataques aéreos y cualquier avión que se esté desplazando por el mapa.

- Cambia probabilidad de quedar sangrando del pie en vez de morir a un 50%.
